### PR TITLE
Add some suggested badges from #1

### DIFF
--- a/badges.py
+++ b/badges.py
@@ -44,6 +44,9 @@ b.add(BADGE_CLASS_ROLE + "/banking", None, "STR_ROLE_BANKING")
 b.add(BADGE_CLASS_ROLE + "/snowplough", None, "STR_ROLE_SNOWPLOUGH")
 b.add(BADGE_CLASS_ROLE + "/utility", None, "STR_ROLE_UTILITY")
 b.add(BADGE_CLASS_ROLE + "/prototype", None, "STR_ROLE_PROTOTYPE")
+b.add(BADGE_CLASS_ROLE + "/city", None, "STR_ROLE_CITY")
+b.add(BADGE_CLASS_ROLE + "/suburb", None, "STR_ROLE_SUBURB")
+b.add(BADGE_CLASS_ROLE + "/regional", None, "STR_ROLE_REGIONAL")
 
 # Country flags
 b.add(BADGE_CLASS_FLAG + "/AD", "flag-icons/ad.svg", "STR_FLAG_AD")

--- a/badges.py
+++ b/badges.py
@@ -341,9 +341,11 @@ b.add(BADGE_CLASS_POWER + "/electric/dc/3kv", "electric_dc.svg", "STR_PROPULSION
 b.add(BADGE_CLASS_POWER + "/turbine", "turbine.svg", "STR_PROPULSION_GAS_TURBINE")
 b.add(BADGE_CLASS_POWER + "/battery", "battery.svg", "STR_PROPULSION_BATTERY")
 
+b.add(BADGE_CLASS_LIVERY + "/company/primary", None, "STR_LIVERY_COMPANY_FIRSTCC")
+b.add(BADGE_CLASS_LIVERY + "/company/secondary", None, "STR_LIVERY_COMPANY_SECONDCC")
+b.add(BADGE_CLASS_LIVERY + "/company/2cc", "2cc.svg", "STR_LIVERY_COMPANY_2CC", flags=BadgeFlags.USE_COMPANY_PALETTE, filters=[filters.MakeCCFilter(filters.HueMasker(300), filters.HueMasker(120))], overlay=True)
 b.add(BADGE_CLASS_LIVERY + "/random/1cc", "dice.svg", "STR_LIVERY_COMPANY_RANDOM_1CC", flags=BadgeFlags.USE_COMPANY_PALETTE, filters=[filters.MakeCCFilter(filters.HueMasker(0), None)])
 b.add(BADGE_CLASS_LIVERY + "/random/2cc", "dice.svg", "STR_LIVERY_COMPANY_RANDOM_2CC", flags=BadgeFlags.USE_COMPANY_PALETTE, filters=[filters.MakeCCFilter(None, filters.HueMasker(0))])
-b.add(BADGE_CLASS_LIVERY + "/2cc", "2cc.svg", "STR_LIVERY_COMPANY_2CC", flags=BadgeFlags.USE_COMPANY_PALETTE, filters=[filters.MakeCCFilter(filters.HueMasker(300), filters.HueMasker(120))], overlay=True)
 
 g.add(grf.Comment("Default Badges"))
 g.add(b)

--- a/badges.py
+++ b/badges.py
@@ -343,6 +343,9 @@ b.add(BADGE_CLASS_POWER + "/electric/dc/1500v", "electric_dc.svg", "STR_PROPULSI
 b.add(BADGE_CLASS_POWER + "/electric/dc/3kv", "electric_dc.svg", "STR_PROPULSION_ELECTRIC_DC_3000", filters=[filters.AdjustHsvFilter(hue=10)])
 b.add(BADGE_CLASS_POWER + "/turbine", "turbine.svg", "STR_PROPULSION_GAS_TURBINE")
 b.add(BADGE_CLASS_POWER + "/battery", "battery.svg", "STR_PROPULSION_BATTERY")
+b.add(BADGE_CLASS_POWER + "/gasoline", None, "STR_PROPULSION_GASOLINE")
+b.add(BADGE_CLASS_POWER + "/natural_gas", None, "STR_PROPULSION_NATURAL_GAS")
+b.add(BADGE_CLASS_POWER + "/hydrogen", None, "STR_PROPULSION_HYDROGEN")
 
 b.add(BADGE_CLASS_LIVERY + "/company/primary", None, "STR_LIVERY_COMPANY_FIRSTCC")
 b.add(BADGE_CLASS_LIVERY + "/company/secondary", None, "STR_LIVERY_COMPANY_SECONDCC")

--- a/badges/lang/english.lng
+++ b/badges/lang/english.lng
@@ -324,6 +324,9 @@ STR_PROPULSION_ELECTRIC_DC_1500            :Electric (DC 1500V)
 STR_PROPULSION_ELECTRIC_DC_3000            :Electric (DC 3kV)
 STR_PROPULSION_GAS_TURBINE                 :Gas Turbine
 STR_PROPULSION_BATTERY                     :Battery
+STR_PROPULSION_GASOLINE                    :Petrol
+STR_PROPULSION_NATURAL_GAS                 :Natural Gas
+STR_PROPULSION_HYDROGEN                    :Hydrogen
 
 # Colours
 STR_LIVERY_COMPANY_FIRSTCC     :Primary company colour

--- a/badges/lang/english.lng
+++ b/badges/lang/english.lng
@@ -25,6 +25,9 @@ STR_ROLE_BANKING             :Banking
 STR_ROLE_SNOWPLOUGH          :Snowplough
 STR_ROLE_UTILITY             :Utility
 STR_ROLE_PROTOTYPE           :Prototype
+STR_ROLE_CITY                :City
+STR_ROLE_SUBURB              :Suburban
+STR_ROLE_REGIONAL            :Regional
 
 # Country flags
 STR_FLAG_AD            :Andorra

--- a/badges/lang/english.lng
+++ b/badges/lang/english.lng
@@ -323,6 +323,8 @@ STR_PROPULSION_GAS_TURBINE                 :Gas Turbine
 STR_PROPULSION_BATTERY                     :Battery
 
 # Colours
+STR_LIVERY_COMPANY_FIRSTCC     :Primary company colour
+STR_LIVERY_COMPANY_SECONDCC    :Secondary company colour
 STR_LIVERY_COMPANY_2CC         :Dual company colour (2CC)
 STR_LIVERY_COMPANY_RANDOM_1CC  :Random based on first company colour
 STR_LIVERY_COMPANY_RANDOM_2CC  :Random based on second company colour


### PR DESCRIPTION
Some suggested badges from #1.

Not sure about the Trolley stuff at the moment.

No icons for these currently. I'm of the opinion that things like "Primary company colour" and "Secondary company colour" don't really need icons, though it is useful to be able to filter for them.